### PR TITLE
fix: 단일 값 배열 변환 기능 추가

### DIFF
--- a/Sources/Parsely/ParselyDecoder.swift
+++ b/Sources/Parsely/ParselyDecoder.swift
@@ -139,8 +139,15 @@ private struct ParselyKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingConta
         // 배열 자동 처리
         let typeName = String(describing: type)
         if typeName.hasPrefix("Array<") || typeName.contains("[") {
+            // 배열 데이터가 있는 경우
             if let arrayData = xmlData[key.stringValue] as? [Any] {
                 let arrayContainer = ParselyUnkeyedDecodingContainer(arrayData: arrayData, codingPath: codingPath + [key])
+                let arrayDecoder = ParselyArrayDecoder(container: arrayContainer)
+                return try T(from: arrayDecoder)
+            }
+            // 단일 값인 경우 배열로 감싸기
+            else if let singleValue = xmlData[key.stringValue] {
+                let arrayContainer = ParselyUnkeyedDecodingContainer(arrayData: [singleValue], codingPath: codingPath + [key])
                 let arrayDecoder = ParselyArrayDecoder(container: arrayContainer)
                 return try T(from: arrayDecoder)
             }


### PR DESCRIPTION
## Issue

Closes #1

## 변경 사항

- `ParselyKeyedDecodingContainer.decode<T>` 메서드에 단일 값 → 배열 변환 로직 추가
- XML에서 요소가 1개만 있어도 배열로 파싱 가능

## 수정 전
```swift
// 1개일 때 파싱 실패 ❌
<styurl>url</styurl>
```

## 수정 후
```swift
// 1개일 때도 파싱 성공 ✅
<styurl>url</styurl>  → ["url"]

// 2개 이상일 때도 정상 동작 ✅
<styurl>url1</styurl>
<styurl>url2</styurl>  → ["url1", "url2"]
```

## 테스트

- [ ] 기존 테스트 통과
- [ ] 단일 값 배열 파싱 테스트 추가 필요 (TODO)

## 체크리스트

- [x] 코드 수정 완료
- [ ] 테스트 코드 작성
- [ ] 문서 업데이트